### PR TITLE
Add RBAC settings flag (enabled/disabled) and some improvements

### DIFF
--- a/gaia.go
+++ b/gaia.go
@@ -324,6 +324,7 @@ type Config struct {
 	DockerRunImage          string
 	DockerWorkerHostURL     string
 	DockerWorkerGRPCHostURL string
+	RBACEnabled             bool
 
 	// Worker
 	WorkerName        string
@@ -341,6 +342,11 @@ type Config struct {
 type StoreConfig struct {
 	ID   int
 	Poll bool
+}
+
+// RBACConfig defines RBAC settings to be stored in DB.
+type RBACConfig struct {
+	Enabled bool `json:"enabled"`
 }
 
 // String returns a pipeline type string back

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -71,9 +71,12 @@ func (s *GaiaHandler) InitHandlers(e *echo.Echo) error {
 		apiGrp.POST("pipeline/:pipelineid/:pipelinetoken/trigger", pipelineProvider.PipelineTrigger)
 
 		// Settings
-		apiAuthGrp.POST("settings/poll/on", SettingsPollOn)
-		apiAuthGrp.POST("settings/poll/off", SettingsPollOff)
-		apiAuthGrp.GET("settings/poll", SettingsPollGet)
+		settingsHandler := newSettingsHandler(s.deps.Store)
+		apiAuthGrp.POST("settings/poll/on", settingsHandler.pollOn)
+		apiAuthGrp.POST("settings/poll/off", settingsHandler.pollOff)
+		apiAuthGrp.GET("settings/poll", settingsHandler.pollGet)
+		apiAuthGrp.GET("settings/rbac", settingsHandler.rbacGet)
+		apiAuthGrp.PUT("settings/rbac", settingsHandler.rbacPut)
 
 		// PipelineRun
 		apiAuthGrp.POST("pipelinerun/:pipelineid/:runid/stop", pipelineProvider.PipelineStop)

--- a/handlers/hook_test.go
+++ b/handlers/hook_test.go
@@ -21,19 +21,19 @@ type MockVaultStorer struct {
 	Error error
 }
 
-var store []byte
+var storeBts []byte
 
 func (mvs *MockVaultStorer) Init() error {
-	store = make([]byte, 0)
+	storeBts = make([]byte, 0)
 	return mvs.Error
 }
 
 func (mvs *MockVaultStorer) Read() ([]byte, error) {
-	return store, mvs.Error
+	return storeBts, mvs.Error
 }
 
 func (mvs *MockVaultStorer) Write(data []byte) error {
-	store = data
+	storeBts = data
 	return mvs.Error
 }
 

--- a/handlers/service.go
+++ b/handlers/service.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"github.com/gaia-pipeline/gaia/security"
 	"github.com/gaia-pipeline/gaia/security/rbac"
+	"github.com/gaia-pipeline/gaia/store"
 	"github.com/gaia-pipeline/gaia/workers/pipeline"
 	"github.com/gaia-pipeline/gaia/workers/scheduler/service"
 )
@@ -13,6 +14,7 @@ type Dependencies struct {
 	PipelineService pipeline.Service
 	Certificate     security.CAAPI
 	RBACService     rbac.Service
+	Store           store.GaiaStore
 }
 
 // GaiaHandler defines handler functions throughout Gaia.

--- a/handlers/settings.go
+++ b/handlers/settings.go
@@ -1,13 +1,13 @@
 package handlers
 
 import (
-	"github.com/gaia-pipeline/gaia/store"
 	"net/http"
 
-	"github.com/gaia-pipeline/gaia/workers/pipeline"
+	"github.com/labstack/echo"
 
 	"github.com/gaia-pipeline/gaia"
-	"github.com/labstack/echo"
+	"github.com/gaia-pipeline/gaia/store"
+	"github.com/gaia-pipeline/gaia/workers/pipeline"
 )
 
 type settingsHandler struct {

--- a/security/rbac/noop.go
+++ b/security/rbac/noop.go
@@ -1,0 +1,53 @@
+package rbac
+
+import "errors"
+
+var errNotEnabled = errors.New("rbac is not enabled")
+
+type noOpService struct{}
+
+// NewNoOpService is used to instantiated a noOpService for when rbac enabled=false.
+func NewNoOpService() Service {
+	return &noOpService{}
+}
+
+// Enforce no-op enforcement. Allows everything.
+func (n noOpService) Enforce(username, method, path string, params map[string]string) (bool, error) {
+	// Allow all
+	return true, nil
+}
+
+// AddRole that errors since rbac is not enabled.
+func (n noOpService) AddRole(role string, roleRules []RoleRule) error {
+	return errNotEnabled
+}
+
+// DeleteRole that errors since rbac is not enabled.
+func (n noOpService) DeleteRole(role string) error {
+	return errNotEnabled
+}
+
+// GetAllRoles that returns nothing since rbac is not enabled.
+func (n noOpService) GetAllRoles() []string {
+	return []string{}
+}
+
+// GetUserAttachedRoles that errors since rbac is not enabled.
+func (n noOpService) GetUserAttachedRoles(username string) ([]string, error) {
+	return nil, errNotEnabled
+}
+
+// GetRoleAttachedUsers that errors since rbac is not enabled.
+func (n noOpService) GetRoleAttachedUsers(role string) ([]string, error) {
+	return nil, errNotEnabled
+}
+
+// AttachRole that errors since rbac is not enabled.
+func (n noOpService) AttachRole(username string, role string) error {
+	return errNotEnabled
+}
+
+// DetachRole that errors since rbac is not enabled.
+func (n noOpService) DetachRole(username string, role string) error {
+	return errNotEnabled
+}

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gaia-pipeline/gaia/security"
 	"github.com/gaia-pipeline/gaia/security/rbac"
 	"github.com/gaia-pipeline/gaia/services"
+	"github.com/gaia-pipeline/gaia/store"
 	"github.com/gaia-pipeline/gaia/workers/agent"
 	"github.com/gaia-pipeline/gaia/workers/pipeline"
 	"github.com/gaia-pipeline/gaia/workers/scheduler/gaiascheduler"
@@ -76,6 +77,7 @@ func init() {
 	fs.StringVar(&gaia.Cfg.DockerRunImage, "docker-run-image", "gaiapipeline/gaia:latest", "Docker image repository name with tag which will be used for running pipelines in a docker container")
 	fs.StringVar(&gaia.Cfg.DockerWorkerHostURL, "docker-worker-host-url", "http://127.0.0.1:8080", "The host url of the primary/worker API endpoint used for docker worker communication")
 	fs.StringVar(&gaia.Cfg.DockerWorkerGRPCHostURL, "docker-worker-grpc-host-url", "127.0.0.1:8989", "The host url of the primary/worker gRPC endpoint used for docker worker communication")
+	fs.BoolVar(&gaia.Cfg.RBACEnabled, "rbac-enabled", false, "Force RBAC to be enabled. Takes priority over value saved within the database")
 
 	// Default values
 	gaia.Cfg.Bolt.Mode = 0600
@@ -250,9 +252,9 @@ func Start() (err error) {
 		Scheduler: schedulerService,
 	})
 
-	enforcerSvc, err := rbac.NewEnforcerSvc(store.CasbinStore())
+	rbacService, err := initRBACService(store)
 	if err != nil {
-		gaia.Cfg.Logger.Error("failed to create new enforcer", "error", err.Error())
+		gaia.Cfg.Logger.Error("error initializing rbac service", "error", err)
 		return err
 	}
 
@@ -261,7 +263,8 @@ func Start() (err error) {
 		Scheduler:       schedulerService,
 		PipelineService: pipelineService,
 		Certificate:     ca,
-		RBACService:     enforcerSvc,
+		RBACService:     rbacService,
+		Store:           store,
 	})
 
 	err = handlerService.InitHandlers(echoInstance)
@@ -340,4 +343,30 @@ func findExecutablePath() (string, error) {
 		return "", err
 	}
 	return filepath.Dir(ex), nil
+}
+
+func initRBACService(store store.GaiaStore) (rbac.Service, error) {
+	enabled := gaia.Cfg.RBACEnabled
+
+	if !enabled {
+		settings, err := store.SettingsRBACGet()
+		if err != nil {
+			gaia.Cfg.Logger.Error("failed to get rbac settings", "error", err.Error())
+			return nil, err
+		}
+		enabled = settings.Enabled
+	}
+
+	if enabled {
+		svc, err := rbac.NewEnforcerSvc(store.CasbinStore())
+		if err != nil {
+			gaia.Cfg.Logger.Error("failed to create new enforcer", "error", err.Error())
+			return nil, err
+		}
+		gaia.Cfg.Logger.Info("rbac enabled")
+		return svc, nil
+	}
+
+	gaia.Cfg.Logger.Info("rbac disabled")
+	return rbac.NewNoOpService(), nil
 }

--- a/store/settings.go
+++ b/store/settings.go
@@ -2,10 +2,16 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 
 	bolt "go.etcd.io/bbolt"
 
 	"github.com/gaia-pipeline/gaia"
+)
+
+const (
+	configSettings     = "gaia_config_settings"
+	rbacConfigSettings = "gaia_rbac_settings"
 )
 
 // SettingsPut puts settings into the store.
@@ -21,7 +27,7 @@ func (s *BoltStore) SettingsPut(c *gaia.StoreConfig) error {
 		}
 
 		// Persist bytes to settings bucket.
-		return b.Put([]byte("gaia_config_settings"), buf)
+		return b.Put([]byte(configSettings), buf)
 	})
 }
 
@@ -34,7 +40,7 @@ func (s *BoltStore) SettingsGet() (*gaia.StoreConfig, error) {
 		b := tx.Bucket(settingsBucket)
 
 		// Get pipeline
-		v := b.Get([]byte("gaia_config_settings"))
+		v := b.Get([]byte(configSettings))
 
 		// Check if we found the pipeline
 		if v == nil {
@@ -45,6 +51,42 @@ func (s *BoltStore) SettingsGet() (*gaia.StoreConfig, error) {
 		err := json.Unmarshal(v, config)
 		if err != nil {
 			return err
+		}
+
+		return nil
+	})
+}
+
+// SettingsRBACPut inserts or updates the rbac config settings.
+func (s *BoltStore) SettingsRBACPut(config gaia.RBACConfig) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(settingsBucket)
+
+		buf, err := json.Marshal(config)
+		if err != nil {
+			return fmt.Errorf("failed to marshal rbac config: %w", err)
+		}
+
+		return b.Put([]byte(rbacConfigSettings), buf)
+	})
+}
+
+// SettingsRBACGet gets the rbac config settings.
+func (s *BoltStore) SettingsRBACGet() (gaia.RBACConfig, error) {
+	var config = gaia.RBACConfig{}
+
+	return config, s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(settingsBucket)
+
+		v := b.Get([]byte(rbacConfigSettings))
+		if v == nil {
+			config = gaia.RBACConfig{Enabled: false}
+			return nil
+		}
+
+		err := json.Unmarshal(v, &config)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal rbac config: %w", err)
 		}
 
 		return nil

--- a/store/store.go
+++ b/store/store.go
@@ -59,9 +59,18 @@ type BoltStore struct {
 	casbinAdapter persist.BatchAdapter
 }
 
+// SettingsStore is the interface that defines methods needed to save settings config into the store.
+type SettingsStore interface {
+	SettingsPut(config *gaia.StoreConfig) error
+	SettingsGet() (*gaia.StoreConfig, error)
+	SettingsRBACPut(config gaia.RBACConfig) error
+	SettingsRBACGet() (gaia.RBACConfig, error)
+}
+
 // GaiaStore is the interface that defines methods needed to store
 // pipeline and user related information.
 type GaiaStore interface {
+	SettingsStore
 	Init(dataPath string) error
 	Close() error
 	CreatePipelinePut(createPipeline *gaia.CreatePipeline) error
@@ -87,8 +96,6 @@ type GaiaStore interface {
 	UserPermissionsPut(perms *gaia.UserPermission) error
 	UserPermissionsGet(username string) (*gaia.UserPermission, error)
 	UserPermissionsDelete(username string) error
-	SettingsPut(config *gaia.StoreConfig) error
-	SettingsGet() (*gaia.StoreConfig, error)
 	WorkerPut(w *gaia.Worker) error
 	WorkerGetAll() ([]*gaia.Worker, error)
 	WorkerDelete(id string) error


### PR DESCRIPTION
* Split the settings store interface out into its own (but nested in store.GaiaStore)
* Added unit tests for settings.go and improved DI on existing ones
* Created a new SettingsHandler to encapsulate the store dependency
* Add ability to save RBAC enabled state into database
* RBAC service is switched to EnforcerService or NoOpService depeneding on enabled state
* RBAC can be enabled or disabled with cmd flag `-rbac-enabled=true/false`